### PR TITLE
test: modmesh-bot e2e target

### DIFF
--- a/.modmesh-bot-e2e
+++ b/.modmesh-bot-e2e
@@ -1,0 +1,2 @@
+modmesh-bot end-to-end smoke target.
+Safe to close once verification is done.


### PR DESCRIPTION
Throwaway PR used as the target for `modmesh-bot`'s end-to-end smoke. Safe to close once verification is done.