### PR TITLE
test: modmesh-bot auto path target (anchi-t2)

### DIFF
--- a/.modmesh-bot-e2e-auto
+++ b/.modmesh-bot-e2e-auto
@@ -1,0 +1,2 @@
+modmesh-bot auto-path e2e target (anchi-t2 fork).
+Approved by tigercosmos to trigger the bot.


### PR DESCRIPTION
Throwaway PR used as the target for `modmesh-bot`'s auto-path end-to-end. Will be approved by tigercosmos to trigger the bot.