### PR TITLE
Add line, triangle, rectangle, and ellipse painter tools

### DIFF
--- a/cpp/solvcon/pilot/DrawTool.cpp
+++ b/cpp/solvcon/pilot/DrawTool.cpp
@@ -5,6 +5,7 @@
 
 #include <solvcon/pilot/DrawTool.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <stdexcept>
 
@@ -12,6 +13,8 @@
 #include <QPainter>
 #include <QPen>
 #include <QPointF>
+#include <QPolygonF>
+#include <QRectF>
 
 namespace solvcon
 {
@@ -32,6 +35,15 @@ void DrawToolBase::paint_preview(
 
 namespace
 {
+
+/// Map a world-space gesture point to widget screen coordinates.
+QPointF to_screen_qpoint(ViewTransform2dFp64 const & view, DrawPoint const & p)
+{
+    double sx = 0.0;
+    double sy = 0.0;
+    view.screen_from_world(p.x, p.y, sx, sy);
+    return QPointF(sx, sy);
+}
 
 /// The default navigation tool: a left-button drag pans and zooms the view instead of drawing.
 class PanTool : public DrawToolBase
@@ -93,14 +105,191 @@ protected:
         {
             throw std::invalid_argument("CircleTool::paint_outline: radius must be positive");
         }
-        double center_x = 0.0;
-        double center_y = 0.0;
-        view.screen_from_world(center.x, center.y, center_x, center_y);
         double const radius_px = view.zoom() * radius;
-        painter.drawEllipse(QPointF(center_x, center_y), radius_px, radius_px);
+        painter.drawEllipse(to_screen_qpoint(view, center), radius_px, radius_px);
     }
 
 }; /* end class CircleTool */
+
+/// Straight line segment from the first gesture point to the second.
+class LineTool : public DrawToolBase
+{
+
+public:
+
+    static constexpr char const * NAME = "line";
+
+    std::string name() const override { return NAME; }
+
+    bool can_draw_shape() const override { return true; }
+
+    void commit(WorldFp64 & world, std::span<DrawPoint const> points) const override
+    {
+        if (points.size() < 2)
+        {
+            throw std::invalid_argument("LineTool::commit: need at least two points");
+        }
+
+        DrawPoint const & p0 = points.front();
+        DrawPoint const & p1 = points.back();
+        world.add_line(p0.x, p0.y, p1.x, p1.y);
+    }
+
+protected:
+
+    void paint_outline(QPainter & painter,
+                       ViewTransform2dFp64 const & view,
+                       std::span<DrawPoint const> points) const override
+    {
+        if (points.size() < 2)
+        {
+            throw std::invalid_argument("LineTool::paint_outline: need at least two points");
+        }
+
+        painter.drawLine(to_screen_qpoint(view, points.front()), to_screen_qpoint(view, points.back()));
+    }
+
+}; /* end class LineTool */
+
+/// Isosceles triangle inscribed in the rectangle closed by the first gesture
+/// point and the cursor (opposite corners).
+/// The base is the horizontal segment between the two corners, and the apex is
+/// the midpoint of the base shifted vertically to the cursor's y coordinate.
+class TriangleTool : public DrawToolBase
+{
+
+public:
+
+    static constexpr char const * NAME = "triangle";
+
+    std::string name() const override { return NAME; }
+
+    bool can_draw_shape() const override { return true; }
+
+    void commit(WorldFp64 & world, std::span<DrawPoint const> points) const override
+    {
+        if (points.size() < 2)
+        {
+            throw std::invalid_argument("TriangleTool::commit: need at least two points");
+        }
+
+        DrawPoint const & anchor = points.front();
+        DrawPoint const & corner = points.back();
+        double const apex_x = (anchor.x + corner.x) * 0.5;
+        world.add_triangle(anchor.x, anchor.y, corner.x, anchor.y, apex_x, corner.y);
+    }
+
+protected:
+
+    void paint_outline(QPainter & painter,
+                       ViewTransform2dFp64 const & view,
+                       std::span<DrawPoint const> points) const override
+    {
+        if (points.size() < 2)
+        {
+            throw std::invalid_argument("TriangleTool::paint_outline: need at least two points");
+        }
+
+        DrawPoint const & anchor = points.front();
+        DrawPoint const & corner = points.back();
+        double const apex_x = (anchor.x + corner.x) * 0.5;
+        QPolygonF const corners{to_screen_qpoint(view, anchor),
+                                to_screen_qpoint(view, {corner.x, anchor.y}),
+                                to_screen_qpoint(view, {apex_x, corner.y})};
+        painter.drawPolygon(corners);
+    }
+
+}; /* end class TriangleTool */
+
+/// Axis-aligned rectangle spanning the two gesture points as opposite corners.
+class RectangleTool : public DrawToolBase
+{
+
+public:
+
+    static constexpr char const * NAME = "rectangle";
+
+    std::string name() const override { return NAME; }
+
+    bool can_draw_shape() const override { return true; }
+
+    void commit(WorldFp64 & world, std::span<DrawPoint const> points) const override
+    {
+        if (points.size() < 2)
+        {
+            throw std::invalid_argument("RectangleTool::commit: need at least two points");
+        }
+
+        DrawPoint const & corner0 = points.front();
+        DrawPoint const & corner1 = points.back();
+        double const min_x = std::min(corner0.x, corner1.x);
+        double const max_x = std::max(corner0.x, corner1.x);
+        double const min_y = std::min(corner0.y, corner1.y);
+        double const max_y = std::max(corner0.y, corner1.y);
+        world.add_rectangle(min_x, min_y, max_x, max_y);
+    }
+
+protected:
+
+    void paint_outline(QPainter & painter,
+                       ViewTransform2dFp64 const & view,
+                       std::span<DrawPoint const> points) const override
+    {
+        if (points.size() < 2)
+        {
+            throw std::invalid_argument("RectangleTool::paint_outline: need at least two points");
+        }
+
+        painter.drawRect(QRectF(to_screen_qpoint(view, points.front()), to_screen_qpoint(view, points.back())).normalized());
+    }
+
+}; /* end class RectangleTool */
+
+/// Axis-aligned ellipse anchored like the circle tool: the first gesture point
+/// is the center, the second fixes a bounding-box corner, so the two
+/// half-axes are the absolute x and y offsets between them.
+class EllipseTool : public DrawToolBase
+{
+
+public:
+
+    static constexpr char const * NAME = "ellipse";
+
+    std::string name() const override { return NAME; }
+
+    bool can_draw_shape() const override { return true; }
+
+    void commit(WorldFp64 & world, std::span<DrawPoint const> points) const override
+    {
+        if (points.size() < 2)
+        {
+            throw std::invalid_argument("EllipseTool::commit: need at least two points");
+        }
+
+        DrawPoint const & center = points.front();
+        DrawPoint const & corner = points.back();
+        world.add_ellipse(center.x, center.y, std::fabs(corner.x - center.x), std::fabs(corner.y - center.y));
+    }
+
+protected:
+
+    void paint_outline(QPainter & painter,
+                       ViewTransform2dFp64 const & view,
+                       std::span<DrawPoint const> points) const override
+    {
+        if (points.size() < 2)
+        {
+            throw std::invalid_argument("EllipseTool::paint_outline: need at least two points");
+        }
+
+        DrawPoint const & center = points.front();
+        DrawPoint const & corner = points.back();
+        double const rx_px = view.zoom() * std::fabs(corner.x - center.x);
+        double const ry_px = view.zoom() * std::fabs(corner.y - center.y);
+        painter.drawEllipse(to_screen_qpoint(view, center), rx_px, ry_px);
+    }
+
+}; /* end class EllipseTool */
 
 /// The tool registry. The first entry is the default tool a fresh canvas
 /// starts with. Add a new shape by writing a `DrawToolBase` subclass above
@@ -114,6 +303,14 @@ struct ToolEntry
 ToolEntry const TOOL_TABLE[] = {
     {PanTool::NAME, []() -> std::unique_ptr<DrawToolBase>
      { return std::make_unique<PanTool>(); }},
+    {LineTool::NAME, []() -> std::unique_ptr<DrawToolBase>
+     { return std::make_unique<LineTool>(); }},
+    {TriangleTool::NAME, []() -> std::unique_ptr<DrawToolBase>
+     { return std::make_unique<TriangleTool>(); }},
+    {RectangleTool::NAME, []() -> std::unique_ptr<DrawToolBase>
+     { return std::make_unique<RectangleTool>(); }},
+    {EllipseTool::NAME, []() -> std::unique_ptr<DrawToolBase>
+     { return std::make_unique<EllipseTool>(); }},
     {CircleTool::NAME, []() -> std::unique_ptr<DrawToolBase>
      { return std::make_unique<CircleTool>(); }},
 };

--- a/solvcon/pilot/_painter_gui.py
+++ b/solvcon/pilot/_painter_gui.py
@@ -27,6 +27,10 @@ class Painter(_gui_common.PilotFeature):
     # A tool with no entry here falls back to its title-cased id.
     TOOL_LABELS = {
         "pan": "Pan / Move",
+        "line": "Line",
+        "triangle": "Triangle",
+        "rectangle": "Rectangle",
+        "ellipse": "Ellipse",
         "circle": "Circle",
     }
 

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -141,16 +141,21 @@ class R2DWidgetWorldTC(unittest.TestCase):
         self.assertEqual(got.zoom, 3.0)
 
     def test_draw_tool_round_trip(self):
-        """setDrawTool selects the tool the Painter toolbox drives; it
-        reads back through the drawTool property, defaults to pan, and
-        rejects an unknown name with ValueError.
+        """setDrawTool selects the tool the Painter toolbox drives; every
+        registered tool reads back through the drawTool property, the
+        default is pan, and an unknown name is rejected with ValueError.
         """
-        self.widget.setDrawTool("circle")
-        self.assertEqual(self.widget.drawTool, "circle")
+        from solvcon.pilot import _pilot_core
+        # The Painter toolbox exposes one button per registered shape tool.
+        self.assertLessEqual(
+            {"pan", "line", "triangle", "rectangle", "ellipse", "circle"},
+            set(_pilot_core.draw_tool_names()))
+        for tool in _pilot_core.draw_tool_names():
+            self.widget.setDrawTool(tool)
+            self.assertEqual(self.widget.drawTool, tool)
         self.widget.setDrawTool("pan")
-        self.assertEqual(self.widget.drawTool, "pan")
         with self.assertRaises(ValueError):
-            self.widget.setDrawTool("triangle")
+            self.widget.setDrawTool("no-such-tool")
         # An invalid request leaves the previous tool untouched.
         self.assertEqual(self.widget.drawTool, "pan")
 
@@ -339,6 +344,37 @@ class PainterToolboxTC(unittest.TestCase):
         _send_mouse(target, 'release', 60, 60)
         # Surviving the repaint is the assertion; the canvas still answers.
         self.assertEqual(self.mgr.currentR2DWidget().drawTool, "circle")
+
+    def test_each_shape_tool_commits_expected_type(self):
+        """Each shape tool maps one rubber-band gesture onto the matching
+        World primitive: drawing grows the canvas world by a single shape of
+        the expected type. This covers the 2-point -> add_* mapping in C++
+        that the headless round-trip test cannot reach.
+        """
+        from PySide6 import QtWidgets
+        from solvcon.pilot import _canvas_gui, _painter_gui
+        painter = _painter_gui.Painter(mgr=self.mgr)
+        canvas = _canvas_gui.Canvas(mgr=self.mgr, painter=painter)
+        canvas._create_blank_2d_canvas()
+        world = canvas._blank_worlds[-1]
+        self.mgr.show()
+        sub = self.mgr.mdiArea.subWindowList()[-1]
+        sub.show()
+        self.mgr.mdiArea.setActiveSubWindow(sub)
+        target = sub.widget()
+        QtWidgets.QApplication.processEvents()
+        # The non-pan tools, paired with the shape type each one commits.
+        shapes = [("line", "line"), ("triangle", "triangle"),
+                  ("rectangle", "rectangle"), ("ellipse", "ellipse"),
+                  ("circle", "circle")]
+        for index, (tool, shape) in enumerate(shapes):
+            self.mgr.setDrawTool(tool)
+            _send_mouse(target, 'press', 40, 40)
+            _send_mouse(target, 'move', 120, 100)
+            _send_mouse(target, 'release', 120, 100)
+            QtWidgets.QApplication.processEvents()
+            self.assertEqual(world.nshape, index + 1)
+            self.assertEqual(world.shape_type_of(index), shape)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add four more drawing tools to the pilot Painter toolbox -- line, triangle, rectangle, and ellipse -- to go with the existing pan and circle. Each maps the two-point rubber-band gesture onto an existing World primitive and records the committed shape in the World.

Related to #754.
