### PR TITLE
Report the Qt and C++23 toolchain in showdep.sh

### DIFF
--- a/contrib/dependency/showdep.sh
+++ b/contrib/dependency/showdep.sh
@@ -5,6 +5,13 @@
 
 echo "gcc path: $(which gcc)"
 echo "gcc version: $(gcc --version)"
+echo "g++ path: $(which g++ 2>/dev/null || echo not-installed)"
+echo "g++ version: $(g++ --version 2>/dev/null | head -1 || echo not-installed)"
+# modmesh's SimpleArray.hpp needs C++23 <mdspan> (GCC >= 14); flag a compiler
+# too old to build it before the build itself does.
+echo "C++23 <mdspan>: $(echo '#include <mdspan>' \
+  | ${CXX:-g++} -std=c++23 -x c++ -fsyntax-only - 2>/dev/null \
+  && echo ok || echo MISSING)"
 echo "cmake path: $(which cmake)"
 echo "cmake version: $(cmake --version)"
 echo "python3 path: $(which python3)"
@@ -27,3 +34,13 @@ echo "flake8 path: $(which flake8)"
 echo "flake8 version: $(flake8 --version)"
 echo "black path: $(which black 2>/dev/null || echo not-installed)"
 echo "black version: $(black --version 2>/dev/null || echo not-installed)"
+# Qt toolchain for the pilot GUI. qsb (the shader baker from ShaderTools) and
+# the Qt platform plugins are what most often go missing on a fresh machine.
+echo "qmake path: $(which qmake6 qmake 2>/dev/null | head -1 || echo not-installed)"
+echo "qmake QT_VERSION: $(qmake6 -query QT_VERSION 2>/dev/null \
+  || qmake -query QT_VERSION 2>/dev/null || echo not-installed)"
+echo "qsb path: $(which qsb 2>/dev/null || echo not-installed)"
+echo "PySide6 version: $(python3 -c 'import PySide6; print(PySide6.__version__)' \
+  2>/dev/null || echo not-installed)"
+echo "shiboken6 version: $(python3 -c 'import shiboken6; print(shiboken6.__version__)' \
+  2>/dev/null || echo not-installed)"


### PR DESCRIPTION
showdep.sh reported the compiler, cmake, Python, numpy, and lint tools, but nothing about the Qt stack the pilot GUI depends on. A machine with a missing or mismatched Qt, shader baker, or PySide6 looked fine in its output, which is exactly the setup that most often breaks a pilot build.

This adds g++, the qmake Qt version, the qsb shader baker, and the PySide6 and shiboken6 versions to the dump. It also probes C++23 <mdspan>, which SimpleArray.hpp requires and the distro default gcc does not ship, so a too-old compiler is flagged up front rather than surfacing as an opaque build error later.
