### PR TITLE
Run AddressSanitizer on Windows via the gtest binary

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -549,8 +549,107 @@ jobs:
           CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_SANITIZER=ON"
         echo "::endgroup::"
 
+  sanitizer_windows:
+
+    needs: [check_skip]
+
+    # The MSVC counterpart of the sanitizer job. MSVC implements only
+    # AddressSanitizer (no leak or undefined), and the instrumented gtest
+    # binary links the ASan runtime directly so ASan initializes at process
+    # start; a stock python.exe loading an instrumented .pyd cannot. Like the
+    # Linux job it is slow, so it runs on the nightly schedule only (set
+    # MMGH_FORCE_SANITIZER to 'enable' to force it on a fork).
+    if: |
+      needs.check_skip.outputs.skip != 'true' && (
+      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') ||
+      vars.MMGH_FORCE_SANITIZER == 'enable')
+
+    name: sanitizer_${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+
+    timeout-minutes: ${{ fromJSON(vars.MMGH_TIMEOUT_BUILD || '60') }}
+
+    strategy:
+      matrix:
+        os: [windows-2022]
+        cmake_build_type: [Release]
+
+      fail-fast: false
+
+    steps:
+
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+
+    - name: event name
+      run: |
+        echo "github.event_name: ${{ github.event_name }}"
+
+    - uses: TheMrMilchmann/setup-msvc-dev@v4
+      with:
+        arch: 'x64'
+
+    # CMake in the windows-2022 image is 3.31.6; solvcon needs >= 4.0.1.
+    - name: install CMake>4.0.1
+      uses: lukka/get-cmake@latest
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Cache vcpkg (install artifacts)
+      uses: actions/cache@v4
+      with:
+        path: |
+          C:\vcpkg\installed
+          C:\vcpkg\downloads
+          C:\vcpkg\buildtrees
+          C:\vcpkg\packages
+        key: vcpkg-${{ runner.os }}-openblas-lapack
+        restore-keys: vcpkg-${{ runner.os }}-
+
+    - name: install BLAS and LAPACK
+      run: |
+        echo "::group::install BLAS and LAPACK"
+        vcpkg install openblas:x64-windows lapack:x64-windows
+        $vcpkg_bin_path = @(
+          "C:\vcpkg\installed\x64-windows\bin",
+          "C:\vcpkg\installed\x64-windows\debug\bin"
+        ) -join ";"
+        echo "$vcpkg_bin_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "::endgroup::"
+
+    - name: dependency by pip
+      run: |
+        echo "::group::dependency by pip"
+        pip3 install -U numpy pytest pybind11
+        echo "::endgroup::"
+
+    - name: cmake run_gtest USE_SANITIZER=ON
+      run: |
+        echo "::group::cmake run_gtest USE_SANITIZER=ON"
+        # AddressSanitizer over the C++ gtest binary. BUILD_QT=OFF keeps the
+        # run headless and USE_GOOGLETEST=ON overrides the Windows preset so
+        # the gtest binary is built. The MSVC toolset bin dir that
+        # setup-msvc-dev puts on PATH also carries the ASan runtime DLL that
+        # the instrumented binary loads at start.
+        cmake -GNinja `
+          -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
+          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
+          -DVCPKG_TARGET_TRIPLET="x64-windows" `
+          -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
+          -DBUILD_QT=OFF `
+          -DUSE_GOOGLETEST=ON `
+          -DUSE_SANITIZER=ON `
+          -S${{ github.workspace }} `
+          -B${{ github.workspace }}/build
+        cmake --build ${{ github.workspace }}/build --target run_gtest
+        echo "::endgroup::"
+
   send_email_on_failure:
-    needs: [standalone_buffer, build, build_windows, sanitizer]
+    needs: [standalone_buffer, build, build_windows, sanitizer, sanitizer_windows]
     # Run if any of the dependencies failed in master branch
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref_name == 'master' && github.event.repository.fork == false }}
     uses: ./.github/workflows/send_email_on_fail.yml
@@ -560,6 +659,7 @@ jobs:
         - build: ${{ needs.build.result }}
         - build_windows: ${{ needs.build_windows.result }}
         - sanitizer: ${{ needs.sanitizer.result }}
+        - sanitizer_windows: ${{ needs.sanitizer_windows.result }}
     secrets:
       EMAIL_USERNAME: ${{ secrets.EMAIL_USERNAME }}
       EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/build.ps1
+++ b/build.ps1
@@ -26,6 +26,8 @@
 #   .\build.ps1 -Test                 then run "pytest tests\" headless
 #   .\build.ps1 -Pilot                then launch the pilot GUI
 #   .\build.ps1 -PilotTest            then run "pilot.exe --mode=pytest" headless
+#   .\build.ps1 -Sanitize             build and run the AddressSanitizer gtest
+#                                     binary (USE_SANITIZER=ON, implies -NoQt)
 #
 # Overridable variables:
 #   SCDV_VS_VERSION: vswhere -version range picking the VS whose cl/vcvars
@@ -41,6 +43,7 @@ param(
     [switch]$Test,
     [switch]$Pilot,
     [switch]$PilotTest,
+    [switch]$Sanitize,
     [switch]$Help
 )
 
@@ -57,6 +60,17 @@ if ($Help) {
         ForEach-Object { if ($_ -notmatch '^\s*$') { $_ -replace '^#\s?', '' } } |
         Select-Object -First 40
     exit 0
+}
+
+# The sanitizer build exercises the C++ gtest binary, not the pilot or the
+# Python module, and mirrors the Linux "make gtest USE_SANITIZER=ON" job. It
+# forces BUILD_QT=OFF so the run stays headless and Qt is out of the picture.
+if ($Sanitize) {
+    if ($Pilot -or $PilotTest) {
+        throw '-Sanitize builds the gtest binary and cannot be combined ' +
+            'with -Pilot or -PilotTest'
+    }
+    $NoQt = $true
 }
 
 # This script lives at the repo root; build that checkout by default.
@@ -167,12 +181,24 @@ $extra = @(
     "-DCMAKE_PREFIX_PATH=$usr"
 )
 if ($NoQt) { $extra += '-DBUILD_QT=OFF' }
+# USE_GOOGLETEST is OFF in the Windows preset; the sanitizer run needs the
+# gtest binary, which links the ASan runtime directly so ASan initializes at
+# process start (unlike loading an instrumented .pyd into a stock python.exe).
+if ($Sanitize) { $extra += '-DUSE_SANITIZER=ON', '-DUSE_GOOGLETEST=ON' }
 
 Push-Location $Repo
 try {
     Write-Host "configuring solvcon (preset $preset, BUILD_QT=$(if ($NoQt) {'OFF'} else {'ON'})) ..."
     & $cmake --preset $preset @extra
     Assert-LastExit 'cmake configure'
+
+    if ($Sanitize) {
+        Write-Host 'building and running the AddressSanitizer gtest binary ...'
+        & $cmake --build --preset $preset --target run_gtest
+        Assert-LastExit 'cmake build run_gtest'
+        Write-Host 'sanitizer gtest run passed'
+        exit 0
+    }
 
     $targets = @('_solvcon')
     if (-not $NoQt) { $targets += 'pilot' }


### PR DESCRIPTION
This builds on #1107, which makes -DUSE_SANITIZER=ON apply real AddressSanitizer on MSVC at the build level. That PR is build-only: it produces an instrumented module but does not give Windows a way to actually run under the sanitizer. This PR adds that runnable path, so it is stacked on #1107 and should be read and merged after it.

The key constraint is that MSVC AddressSanitizer works on a native executable that links the ASan runtime directly, because ASan then initializes at process start. It does not work by importing an instrumented _solvcon.pyd into a stock python.exe, where the runtime would initialize too late in a host that is not itself instrumented. The natural entry point is therefore the C++ gtest binary, exactly as the Linux sanitizer job already runs ASan through run_gtest rather than pytest.

Two pieces make that available. build.ps1 gains a -Sanitize switch that configures USE_SANITIZER=ON with USE_GOOGLETEST=ON, forces BUILD_QT=OFF, and builds and runs run_gtest, mirroring "make gtest USE_SANITIZER=ON" on Linux. A new sanitizer_windows CI job does the same on an MSVC toolchain with vcpkg and Ninja, gated to the nightly schedule like the existing Linux sanitizer job, and wired into the failure-notification summary.

The build.ps1 path was verified on a Windows Server 2022 machine with MSVC 19.44: the instrumented gtest binary built and ran with all 211 tests passing and no sanitizer diagnostics. The CI job has been validated only for YAML syntax and by mirroring the existing Windows build and Linux sanitizer jobs; it has not yet run on GitHub Actions.
