### PR TITLE
Run each pilot GUI test once per operating system on CI

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -224,8 +224,10 @@ jobs:
           install_name_tool -add_rpath $(qtpaths --install-prefix)/lib ${PYSIDE6_PATH}/QtCore.abi3.so
           JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON" ; \
         fi
-        # Left at the default so one job runs the GUI tests with their windows
-        # off the screen; run_pilot_pytest below maps its windows.
+        # The live-window widget classes run once per OS, in run_pilot_pytest
+        # below; what stays here needs no window, so SOLVCON_TEST_SHOW_WINDOWS
+        # is left at the default. A schedule run leaves the guard empty.
+        export SOLVCON_SKIP_PILOT_WIDGET_TESTS=${{ github.event_name != 'schedule' && '1' || '' }}
         make pytest ${JOB_MAKE_ARGS}
         echo "::endgroup::"
 

--- a/solvcon/pilot/painter/_canvas.py
+++ b/solvcon/pilot/painter/_canvas.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+The Canvas page of the Painter inspector: how the canvas shows the world.
+"""
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+from ._sections import Placeholder, Section
+from ._style import blend, mono_font, rule, shade, PaletteStyled
+
+__all__ = [
+    'CanvasPage',
+]
+
+
+def _format_zoom(zoom):
+    """Return the zoom as the readout shows it, screen pixels per world unit
+    read as a percentage."""
+    percent = 100.0 * zoom
+    # Whole percents while the view is anywhere near its own scale, which is
+    # what the design shows; a far zoom out needs the digits below one.
+    return f"{round(percent):g}%" if percent >= 1.0 else f"{percent:.3g}%"
+
+
+class _Readout(QtWidgets.QFrame):
+    """One boxed reading: what it measures, then the number."""
+
+    _HEIGHT = 28
+    _MARGINS = (8, 0, 8, 0)
+    _GAP = 8
+
+    def __init__(self, label, parent=None):
+        super().__init__(parent)
+        self.setObjectName("box")
+        self.setFixedHeight(self._HEIGHT)
+        name = QtWidgets.QLabel(label, self)
+        name.setObjectName("name")
+        self._value = QtWidgets.QLabel(self)
+        self._value.setObjectName("value")
+        self._value.setFont(mono_font())
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(*self._MARGINS)
+        layout.setSpacing(self._GAP)
+        layout.addWidget(name)
+        layout.addStretch(1)
+        layout.addWidget(self._value)
+
+    @property
+    def value(self):
+        """The number the box reads, as it is written there."""
+        return self._value.text()
+
+    def set_value(self, text):
+        """Show ``text``, which is empty for a box reading nothing."""
+        self._value.setText(text)
+
+
+class CanvasPage(PaletteStyled):
+    """The inspector's Canvas page: the view over the bound canvas.
+
+    Like the other pages, this one reads the canvas it is bound to on a timer,
+    because the view carries no change signal. What the poll compares is the
+    zoom, which is what the View section reads; the pan is left out, since it
+    moves the view without changing that.
+
+    The buttons that act on the view, and the sections the model cannot back
+    yet, arrive with later steps of the redesign; they stand here as their
+    designed titles, greyed out.
+    """
+
+    # Poll period in milliseconds, the Design page's rate and for its reason:
+    # the reading is cheap enough to take this often, and a slower one reads as
+    # lag while the wheel moves the zoom under it.
+    _POLL_MS = 60
+
+    #: The greyed-out sections, as ``(title, what the section waits for)``.
+    PLACEHOLDERS = (
+        ("Grid", "grid and snap options"),
+        ("Axes & origin", "axes and origin styling"),
+        ("Background", "background presets"),
+        ("Units", "display units and precision"),
+    )
+
+    _LABEL_PX = 10
+    _VALUE_PX = 11
+    _RADIUS = 5
+
+    # How far each of these sits from the panel color.
+    _MUTED_MIX = 0.35
+    _GREYED_MIX = 0.6
+    _BORDER_MIX = 0.25
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._source = None
+        self._key = None
+        self.placeholders = {}
+        self._build()
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(self._POLL_MS)
+        self._timer.timeout.connect(self.refresh)
+        self._apply_style()
+        self._render()
+
+    @property
+    def zoom(self):
+        """The zoom the readout shows, as it is written there."""
+        return self._readout.value
+
+    def set_canvas_source(self, source):
+        """Bind the page to ``source``, a callable handing back the canvas.
+
+        The callable returns the 2D canvas to read, or ``None`` when none is
+        active. The canvas is asked for on every read rather than held,
+        because it is a C++ widget owned by its sub-window: a reference kept
+        across the window's close outlives the object behind it, and the next
+        read walks freed memory.
+        """
+        self._source = source
+        self._key = self._state_key()
+        self._render()
+
+    def showEvent(self, event):
+        """Poll the bound canvas only while the page is on screen."""
+        super().showEvent(event)
+        self.refresh()
+        self._timer.start()
+
+    def hideEvent(self, event):
+        """Stop polling once the page leaves the screen."""
+        super().hideEvent(event)
+        self._timer.stop()
+
+    def refresh(self):
+        """Redraw the page when the canvas it is bound to has changed."""
+        key = self._state_key()
+        if key == self._key:
+            return
+        self._key = key
+        self._render()
+
+    def _build(self):
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self._build_view())
+        for title, waits_for in self.PLACEHOLDERS:
+            layout.addWidget(rule(QtWidgets.QFrame.HLine))
+            self.placeholders[title] = Placeholder(
+                title, waits_for, parent=self)
+            layout.addWidget(self.placeholders[title])
+
+        layout.addStretch(1)
+
+    def _build_view(self):
+        """Build the View section, for now the zoom readout alone."""
+        self._view = Section("View", parent=self)
+        self._readout = _Readout("Zoom", self._view)
+        self._view.body.addWidget(self._readout)
+        return self._view
+
+    def _canvas(self):
+        """The 2D canvas to read, or ``None`` when none is active."""
+        return None if self._source is None else self._source()
+
+    def _state_key(self):
+        """What the page shows, as a value the poll can compare."""
+        widget = self._canvas()
+        return None if widget is None else widget.viewTransform.zoom
+
+    def _render(self):
+        """Show the zoom of the canvas the page is bound to."""
+        self._readout.set_value(
+            "" if self._key is None else _format_zoom(self._key))
+        self._view.setEnabled(self._key is not None)
+
+    def _apply_style(self):
+        """Color the section heads and the readout from the palette."""
+        palette = self.palette()
+        text = palette.color(QtGui.QPalette.WindowText)
+        panel = palette.color(QtGui.QPalette.Window)
+        muted = blend(text, panel, self._MUTED_MIX)
+        self.setStyleSheet(f"""
+            QLabel#section {{
+                color: {muted.name()};
+            }}
+            QLabel#section:disabled {{
+                color: {blend(text, panel, self._GREYED_MIX).name()};
+            }}
+            QFrame#box {{
+                border: 1px solid {shade(self, self._BORDER_MIX).name()};
+                border-radius: {self._RADIUS}px;
+                background: {palette.color(QtGui.QPalette.Base).name()};
+            }}
+            QLabel#name {{
+                font-size: {self._LABEL_PX}px;
+                color: {muted.name()};
+            }}
+            QLabel#value {{
+                font-size: {self._VALUE_PX}px;
+            }}
+            """)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/solvcon/pilot/painter/_design.py
+++ b/solvcon/pilot/painter/_design.py
@@ -10,6 +10,7 @@ import math
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import _icons
+from ._sections import Placeholder
 from ._style import (blend, mono_font, obb_metrics, rule, shade,
                      PaletteStyled)
 
@@ -133,34 +134,6 @@ class _Field(QtWidgets.QFrame):
             self.committed.emit(value)
 
 
-class _Placeholder(QtWidgets.QWidget):
-    """A greyed-out stand-in for a section the model cannot fill yet.
-
-    It carries the design's own title, so the page keeps its designed shape.
-    """
-
-    _ARROW = chr(0x25b8)
-    _MARGINS = (12, 11, 12, 11)
-    _FONT_PX = 10
-    _LETTER_SPACING = 110
-
-    def __init__(self, title, waits_for, folded=True, parent=None):
-        super().__init__(parent)
-        text = f"{self._ARROW}  {title.upper()}" if folded else title.upper()
-        label = QtWidgets.QLabel(text, self)
-        label.setObjectName("section")
-        font = label.font()
-        font.setPixelSize(self._FONT_PX)
-        font.setLetterSpacing(QtGui.QFont.PercentageSpacing,
-                              self._LETTER_SPACING)
-        label.setFont(font)
-        layout = QtWidgets.QHBoxLayout(self)
-        layout.setContentsMargins(*self._MARGINS)
-        layout.addWidget(label)
-        self.setToolTip(f"{title}  (needs {waits_for})")
-        self.setEnabled(False)
-
-
 class DesignPage(PaletteStyled):
     """The inspector's Design page: the selected shape and its position.
 
@@ -271,7 +244,7 @@ class DesignPage(PaletteStyled):
         layout.addStretch(1)
 
     def _add_placeholder(self, title, waits_for, folded=True):
-        self.placeholders[title] = _Placeholder(title, waits_for, folded, self)
+        self.placeholders[title] = Placeholder(title, waits_for, folded, self)
         return self.placeholders[title]
 
     def _build_selection(self):

--- a/solvcon/pilot/painter/_gui.py
+++ b/solvcon/pilot/painter/_gui.py
@@ -8,6 +8,7 @@ Painter toolbox for the 2D canvas: the draw tool selector and the inspector.
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import _icons
+from ._canvas import CanvasPage
 from ._design import DesignPage
 from ._layers import LayersPage
 from ._style import blend, rule, shade, PaletteStyled
@@ -295,9 +296,7 @@ class PainterPanel(QtWidgets.QWidget):
     ``draw.tool`` action the Canvas menu also shows, plus the greyed-out Text
     and Grid slots the model cannot back yet. The inspector stacks the
     Design, Layers, and Canvas pages under a segmented tab row that selects
-    among them, and hands the active canvas to whichever page reads one. The
-    Canvas page arrives with a later step of the redesign, so it is still a
-    greyed-out placeholder naming what it will hold.
+    among them, and hands the active canvas to every page.
     """
 
     # The design's inspector width, in device-independent pixels. It is the
@@ -307,11 +306,6 @@ class PainterPanel(QtWidgets.QWidget):
 
     #: Inspector page names, in tab order.
     PAGES = ("Design", "Layers", "Canvas")
-
-    # What a page yet to be built says it will hold.
-    _PLACEHOLDERS = {
-        "Canvas": "View, grid, axes, background, and units",
-    }
 
     def __init__(self, tool_actions, short_labels=None, parent=None):
         """
@@ -330,6 +324,9 @@ class PainterPanel(QtWidgets.QWidget):
         self._design = DesignPage(self._stack)
         self._layers = LayersPage(self._stack)
         self._layers.picked.connect(self._on_picked)
+        self._canvas = CanvasPage(self._stack)
+        # In tab order, so the stack and the tab row cannot drift apart.
+        self._pages = (self._design, self._layers, self._canvas)
         self._tabs = _SegmentedTabs(self.PAGES)
         self._tabs.selected.connect(self.show_page)
         self._inspector = self._build_inspector()
@@ -365,10 +362,15 @@ class PainterPanel(QtWidgets.QWidget):
         """The Layers page."""
         return self._layers
 
+    @property
+    def canvas(self):
+        """The Canvas page."""
+        return self._canvas
+
     def set_canvas_source(self, source):
         """Tell the inspector how to reach the active 2D canvas."""
         self._source = source
-        for page in (self._design, self._layers):
+        for page in self._pages:
             page.set_canvas_source(source)
 
     def _on_picked(self, shape_id):
@@ -400,18 +402,14 @@ class PainterPanel(QtWidgets.QWidget):
         comes back into view, so a canvas switch does not pay for pages the
         user is not looking at.
         """
-        for page in (self._design, self._layers):
+        for page in self._pages:
             if page.isVisible():
                 page.refresh()
 
     def _build_inspector(self):
         """Build the tab row over the stack of pages."""
-        pages = {"Design": self._design, "Layers": self._layers}
-        for name in self.PAGES:
-            page = pages.get(name)
-            self._stack.addWidget(
-                self._build_page(self._PLACEHOLDERS[name])
-                if page is None else page)
+        for page in self._pages:
+            self._stack.addWidget(page)
         inspector = QtWidgets.QWidget(self)
         inspector.setMinimumWidth(self._INSPECTOR_WIDTH)
         layout = QtWidgets.QVBoxLayout(inspector)
@@ -421,18 +419,6 @@ class PainterPanel(QtWidgets.QWidget):
         layout.addWidget(rule(QtWidgets.QFrame.HLine))
         layout.addWidget(self._stack, 1)
         return inspector
-
-    def _build_page(self, placeholder):
-        """Build one inspector page, for now just its greyed-out summary."""
-        page = QtWidgets.QWidget(self._stack)
-        layout = QtWidgets.QVBoxLayout(page)
-        layout.setContentsMargins(8, 8, 8, 8)
-        label = QtWidgets.QLabel(placeholder, page)
-        label.setWordWrap(True)
-        label.setEnabled(False)
-        layout.addWidget(label)
-        layout.addStretch(1)
-        return page
 
     def current_page(self):
         """The name of the page the inspector shows."""

--- a/solvcon/pilot/painter/_sections.py
+++ b/solvcon/pilot/painter/_sections.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+The titled sections the pages of the Painter inspector are built from.
+
+The design heads every section the same way, a small uppercase title with a
+fold arrow, and leaves several of them to follow-ups. Both the open section and
+the greyed-out stand-in live here, so a page that fills one and a page that
+still waits on the model draw the same head.
+"""
+
+from PySide6 import QtGui, QtWidgets
+
+__all__ = [
+    'ARROW_OPEN',
+    'ARROW_FOLDED',
+    'Section',
+    'Placeholder',
+]
+
+#: The fold arrow of an open section and of a folded one.
+ARROW_OPEN = chr(0x25be)
+ARROW_FOLDED = chr(0x25b8)
+
+_MARGINS = (12, 11, 12, 11)
+_GAP = 9
+_FONT_PX = 10
+_LETTER_SPACING = 110
+
+
+class Section(QtWidgets.QWidget):
+    """One section of a page: the design's head over the controls it holds.
+
+    A page adds its controls to :attr:`body`, the layout the head already sits
+    in, so they land under the title with the design's own spacing.
+    """
+
+    def __init__(self, title, arrow=ARROW_OPEN, parent=None):
+        """
+        :param arrow: The fold arrow to head the title with, or an empty
+            string for a section that folds nothing.
+        :type arrow: str
+        """
+        super().__init__(parent)
+        self.body = QtWidgets.QVBoxLayout(self)
+        self.body.setContentsMargins(*_MARGINS)
+        self.body.setSpacing(_GAP)
+        self.body.addWidget(self._build_title(title, arrow))
+
+    def _build_title(self, title, arrow):
+        label = QtWidgets.QLabel(
+            f"{arrow}  {title.upper()}" if arrow else title.upper(), self)
+        label.setObjectName("section")
+        font = label.font()
+        font.setPixelSize(_FONT_PX)
+        font.setLetterSpacing(QtGui.QFont.PercentageSpacing, _LETTER_SPACING)
+        label.setFont(font)
+        return label
+
+
+class Placeholder(Section):
+    """A greyed-out stand-in for a section the model cannot fill yet.
+
+    It carries the design's own title, so the page keeps its designed shape.
+    """
+
+    def __init__(self, title, waits_for, folded=True, parent=None):
+        super().__init__(title, ARROW_FOLDED if folded else "", parent)
+        self.setToolTip(f"{title}  (needs {waits_for})")
+        self.setEnabled(False)
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/pilot_ci.py
+++ b/tests/pilot_ci.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Let CI run each pilot GUI test once per operating system.
+
+Every pilot GUI test runs twice on a pull request: once under python plus
+PySide6 (``make pytest BUILD_QT=ON``) and once inside the pilot binary
+(``make run_pilot_pytest``), and the widget classes are where both passes
+spend their time. The pilot binary embeds the interpreter nothing else
+exercises, so it keeps the full GUI pass, and the python pass exports
+``SOLVCON_SKIP_PILOT_WIDGET_TESTS`` to drop the widget classes while it still
+runs the headless pilot classes and the whole non-GUI suite. A developer
+running ``make pytest`` leaves the variable unset and sees no change.
+
+The guard is an environment variable rather than a pytest marker because both
+Qt hosts read it the same way, the test files stay pure unittest, and they
+remain usable under plain ``python -m unittest``.
+"""
+
+
+import os
+
+
+def _flag(name):
+    return (os.getenv(name) or '').upper() in ('1', 'ON', 'YES', 'TRUE')
+
+
+SKIP_PILOT_WIDGETS = _flag('SOLVCON_SKIP_PILOT_WIDGET_TESTS')
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -13,6 +13,7 @@ from xml.etree import ElementTree
 import numpy as np
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -389,7 +390,7 @@ class R2DWidgetWorldTC(unittest.TestCase):
                 "circle interior should be hollow")
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "live-GUI interaction needs a real window surface")
 class R2DWidgetSelectToolTC(unittest.TestCase):
     """Drive the select tool through select, move, rotate, and deselect."""
@@ -1049,7 +1050,7 @@ class R2DWidgetExportOverlayTC(unittest.TestCase):
         self.assertGreater(labeled, plain)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "theme switching needs a real window surface")
 class R2DWidgetThemeTC(unittest.TestCase):
     """The painted frame follows the theme, not just the palette the widget
@@ -1098,7 +1099,7 @@ class R2DWidgetThemeTC(unittest.TestCase):
                                  self.widget.canvasPalette["background"])
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "live-GUI interaction needs a real window surface")
 class PainterToolboxTC(unittest.TestCase):
     """Run-through coverage of the Painter toolbox and the 'Create blank 2D

--- a/tests/test_pilot_agent.py
+++ b/tests/test_pilot_agent.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -55,7 +56,7 @@ class _TranslateBackend:
                  "dx": 1.0, "dy": 0.0}])
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class AgentPanelTC(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pilot_agent_control.py
+++ b/tests/test_pilot_agent_control.py
@@ -12,6 +12,7 @@ import tempfile
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot, agent
@@ -30,7 +31,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class _PilotTC(unittest.TestCase):
     """Shared setup: a shown main window with an empty MDI area, so every

--- a/tests/test_pilot_bar.py
+++ b/tests/test_pilot_bar.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -22,7 +23,7 @@ BUILTINS = ["File", "Edit", "View", "One", "Mesh", "Canvas", "Profiling",
             "Window"]
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class BarStructureTC(unittest.TestCase):
     def test_full_bar_is_assembled_from_the_model(self):

--- a/tests/test_pilot_camera_menu.py
+++ b/tests/test_pilot_camera_menu.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -19,7 +20,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class CameraMenuTC(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pilot_draw_tool.py
+++ b/tests/test_pilot_draw_tool.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -66,7 +67,7 @@ class PainterIconTC(unittest.TestCase):
                 self.assertLess(scaled[3], 2 * self._SIZE - 1)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class DrawToolTC(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pilot_menu_model.py
+++ b/tests/test_pilot_menu_model.py
@@ -7,6 +7,7 @@ import itertools
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -25,7 +26,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
 _TAG = itertools.count()
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class MenuModelTC(unittest.TestCase):
     def setUp(self):
@@ -95,7 +96,7 @@ class MenuModelTC(unittest.TestCase):
                          [self.tag + "B", self.tag + "A"])
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class MenuPlacementTC(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pilot_painter_canvas.py
+++ b/tests/test_pilot_painter_canvas.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Tests for the Canvas page of the Painter inspector.
+"""
+
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot import painter as _painter
+    from solvcon.pilot.painter import _canvas
+    from PySide6 import QtGui
+except ImportError:
+    pilot = None
+
+
+def _view(pan_x=0.0, pan_y=0.0, zoom=1.0):
+    """A view transform panned and zoomed as given."""
+    view = solvcon.ViewTransform2dFp64()
+    view.pan_x = pan_x
+    view.pan_y = pan_y
+    view.zoom = zoom
+    return view
+
+
+class _StubCanvas:
+    """Stand-in for the 2D canvas: a view over a world.
+
+    The real canvas hands back a detached copy of its transform, so the stub
+    copies too; a page that wrote into the canvas's own transform would pass
+    here and fail there.
+    """
+
+    def __init__(self, world):
+        self.world = world
+        self._view = _view()
+
+    @property
+    def viewTransform(self):
+        return _view(self._view.pan_x, self._view.pan_y, self._view.zoom)
+
+    def setViewTransform(self, view):
+        self._view = _view(view.pan_x, view.pan_y, view.zoom)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class PainterCanvasPageTC(unittest.TestCase):
+    """What the View section reads off the canvas it is bound to."""
+
+    @classmethod
+    def setUpClass(cls):
+        # No window needed, only a live QGuiApplication to hold a widget.
+        pilot.RManager.instance.setUp()
+
+    def setUp(self):
+        self.world = solvcon.WorldFp64()
+        self.canvas = _StubCanvas(self.world)
+        self.page = _canvas.CanvasPage()
+        self.page.set_canvas_source(lambda: self.canvas)
+
+    def _set_view(self, **kw):
+        self.canvas.setViewTransform(_view(**kw))
+        self.page.refresh()
+
+    def test_the_readout_reads_the_zoom_as_a_percentage(self):
+        self.assertEqual(self.page.zoom, "100%")
+        self._set_view(zoom=0.6833)
+        self.assertEqual(self.page.zoom, "68%")
+        self._set_view(zoom=2.5)
+        self.assertEqual(self.page.zoom, "250%")
+
+    def test_a_far_zoom_out_keeps_the_digits_below_one(self):
+        self._set_view(zoom=0.0025)
+        self.assertEqual(self.page.zoom, "0.25%")
+
+    def test_a_zoom_the_world_cannot_see_still_refreshes(self):
+        # Zooming moves no geometry, so a poll watching the world alone would
+        # leave the readout behind.
+        self.world.add_circle(0, 0, 1)
+        self.page.refresh()
+        before = self.page.zoom
+        self._set_view(zoom=4.0)
+        self.assertNotEqual(self.page.zoom, before)
+        self.assertEqual(self.page.zoom, "400%")
+
+    def test_a_pan_leaves_the_readout_where_it_stands(self):
+        # The page shows the zoom alone, and the poll compares what it shows.
+        self._set_view(zoom=2.0)
+        self._set_view(pan_x=120.0, pan_y=-40.0, zoom=2.0)
+        self.assertEqual(self.page.zoom, "200%")
+
+    def test_binding_another_canvas_shows_that_one(self):
+        # The panel rebinds the page as the active sub-window changes, and what
+        # it reads follows the canvas handed over.
+        self._set_view(zoom=3.0)
+        self.page.set_canvas_source(lambda: _StubCanvas(self.world))
+        self.assertEqual(self.page.zoom, "100%")
+
+    def test_without_a_canvas_the_view_section_is_dead(self):
+        self.canvas = None
+        self.page.refresh()
+        self.assertEqual(self.page.zoom, "")
+        self.assertFalse(self.page._view.isEnabled())
+
+    def test_sections_the_model_cannot_fill_are_greyed_out(self):
+        self.assertEqual(list(self.page.placeholders),
+                         ["Grid", "Axes & origin", "Background", "Units"])
+        for title, section in self.page.placeholders.items():
+            with self.subTest(title=title):
+                self.assertFalse(section.isEnabled())
+                self.assertIn("needs", section.toolTip())
+
+    def test_the_page_fits_the_designed_inspector(self):
+        self.assertLessEqual(self.page.sizeHint().width(),
+                             _painter.PainterPanel._INSPECTOR_WIDTH)
+
+    def test_the_page_restyles_with_the_palette(self):
+        # A color captured once would survive a theme switch as is.
+        before = self.page.styleSheet()
+        palette = QtGui.QPalette(self.page.palette())
+        palette.setColor(QtGui.QPalette.Window, QtGui.QColor("black"))
+        palette.setColor(QtGui.QPalette.WindowText, QtGui.QColor("white"))
+        self.page.setPalette(palette)
+        self.assertNotEqual(self.page.styleSheet(), before)
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_painter_design.py
+++ b/tests/test_pilot_painter_design.py
@@ -10,6 +10,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -240,7 +241,7 @@ class PainterDesignPageTC(unittest.TestCase):
         self.assertNotEqual(self.page._icon.pixmap().toImage(), icon)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class PainterDesignCanvasTC(unittest.TestCase):
     """The page against a real canvas, bound by the Painter dock."""

--- a/tests/test_pilot_painter_layers.py
+++ b/tests/test_pilot_painter_layers.py
@@ -10,6 +10,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -221,7 +222,7 @@ class PainterLayersPageTC(unittest.TestCase):
         self.assertNotEqual(self.page.shown_rows[0].icon.toImage(), icon)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class PainterLayersCanvasTC(unittest.TestCase):
     """The page against a real canvas, bound by the Painter dock."""

--- a/tests/test_pilot_shortcut.py
+++ b/tests/test_pilot_shortcut.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -220,7 +221,7 @@ class ShortcutResolutionTC(unittest.TestCase):
         self.assertIn(frozenset({"edit.undo", "window.console"}), pairs)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ShortcutTC(unittest.TestCase):
     """Live QAction bindings for the commands routed through the roof."""
@@ -280,7 +281,7 @@ class ShortcutTC(unittest.TestCase):
             self.assertEqual(action.menuRole(), QtGui.QAction.NoRole)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ApplyShortcutHelperTC(unittest.TestCase):
     """apply_shortcut installs a binding by objectName without hand wiring."""
@@ -310,7 +311,8 @@ class ApplyShortcutHelperTC(unittest.TestCase):
         self.assertEqual(act.menuRole(), QtGui.QAction.AboutRole)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT or QTest is None,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS
+                 or not solvcon.HAS_PILOT or QTest is None,
                  "live key delivery needs a real window surface and QtTest")
 class DrawToolShortcutTC(unittest.TestCase):
     """The draw-tool letters reach a focused canvas and nothing else."""

--- a/tests/test_pilot_solution_info.py
+++ b/tests/test_pilot_solution_info.py
@@ -9,6 +9,7 @@ import unittest
 import numpy as np
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 from solvcon.multidim.euler import oblique
 
 try:
@@ -70,7 +71,7 @@ class ComputeFieldTC(unittest.TestCase):
             density, svr.so0n.ndarray[svr.ngstcell:, 0])
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class SolutionInfoTC(unittest.TestCase):
     def setUp(self):
@@ -189,7 +190,7 @@ class SolutionInfoTC(unittest.TestCase):
         QApplication.processEvents()
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class SolutionInspectorTC(unittest.TestCase):
     """The wired controller refreshes the inspector when a run sets the

--- a/tests/test_pilot_terminal.py
+++ b/tests/test_pilot_terminal.py
@@ -14,6 +14,7 @@ events, so they need the Qt pilot but no on-screen rendering.
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -35,8 +36,9 @@ def _send_key(widget, key, text="", mod=None):
         QtWidgets.QApplication.sendEvent(widget, event)
 
 
-@unittest.skipUnless(solvcon.HAS_PILOT and pilot is not None,
-                     "Qt pilot is not built")
+@unittest.skipUnless(solvcon.HAS_PILOT and pilot is not None
+                     and not SKIP_PILOT_WIDGETS,
+                     "Qt pilot is not built, or widget tests are skipped")
 class TerminalWidgetTC(unittest.TestCase):
 
     @classmethod

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -25,7 +26,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeManagerTC(unittest.TestCase):
     def setUp(self):
@@ -67,7 +68,7 @@ class ThemeManagerTC(unittest.TestCase):
         self.assertEqual(self.mgr.theme_mode, "system")
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeMenuTC(unittest.TestCase):
     def setUp(self):
@@ -128,7 +129,7 @@ class ThemeMenuTC(unittest.TestCase):
         self.assertEqual(checked.objectName(), "theme.mode_dark")
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeLookTC(unittest.TestCase):
     def setUp(self):
@@ -181,7 +182,7 @@ class ThemeLookTC(unittest.TestCase):
                          "theme.look_system")
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemePolishTC(unittest.TestCase):
     def setUp(self):
@@ -217,7 +218,7 @@ class ThemePolishTC(unittest.TestCase):
         self.assertEqual(settings.value("theme/look"), "system")
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeCanvasTC(unittest.TestCase):
     """The 2D canvas fills every pixel itself instead of letting the style
@@ -266,7 +267,7 @@ class ThemeCanvasTC(unittest.TestCase):
             self.app.palette().color(QPalette.Window).lightness())
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeConsoleTC(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pilot_toggle_action.py
+++ b/tests/test_pilot_toggle_action.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -21,7 +22,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ToggleActionBridgeTC(unittest.TestCase):
 

--- a/tests/test_pilot_tree_panel.py
+++ b/tests/test_pilot_tree_panel.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -140,7 +141,7 @@ class MakeMeshInfoTC(unittest.TestCase):
         self.assertEqual(binfo, [[0, mh.nbound]])
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class MeshInfoTreeTC(unittest.TestCase):
     def setUp(self):
@@ -161,7 +162,7 @@ class MeshInfoTreeTC(unittest.TestCase):
                          Qt.Checked)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class EntityTreeWidgetTC(unittest.TestCase):
     def setUp(self):
@@ -197,7 +198,7 @@ class EntityTreeWidgetTC(unittest.TestCase):
         self.assertFalse(tree._timer.isActive())
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class TreePanelTC(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pilot_ui_state.py
+++ b/tests/test_pilot_ui_state.py
@@ -12,6 +12,7 @@ import tempfile
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -45,7 +46,7 @@ class FakePart(object):
         return self.value
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class GeometrySeamTC(unittest.TestCase):
     """Drive the geometry policy against a hidden, fully controlled window.
@@ -109,7 +110,7 @@ class GeometrySeamTC(unittest.TestCase):
         self.assertEqual(part.capture()["height"], 420)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class UiStateTC(unittest.TestCase):
     """UiState coordinates any number of named parts, not windows alone."""

--- a/tests/test_pilot_window_menu.py
+++ b/tests/test_pilot_window_menu.py
@@ -14,6 +14,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -30,7 +31,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class WindowMenuTC(unittest.TestCase):
     """Drive the WindowManager list through the live "Window" menu."""


### PR DESCRIPTION
Validation run on the fork. Related to #1222.

Every pilot GUI test runs twice on a pull request: once under python plus PySide6 (`make pytest BUILD_QT=ON`) and once inside the pilot binary (`make run_pilot_pytest`). The widget classes are where both passes spend their time, about 98 s and 73 s respectively on ubuntu and 138 s and 101 s on macos, against about 3 s for the whole non-GUI suite.

The pilot binary embeds an interpreter nothing else exercises, so it keeps the full GUI pass. The python pass now exports `SOLVCON_SKIP_PILOT_WIDGET_TESTS` and drops the live-window widget classes, while still running the import check, the headless pilot classes, and every non-GUI test. A new `tests/pilot_ci.py` holds the guard and explains why it exists. A schedule event leaves the guard empty, so the nightly `build` job still runs every GUI test in both Qt hosts.

Local runs are unaffected: a developer running `make pytest` leaves the variable unset.

What this run is meant to prove: the surviving test set passes in both Qt hosts, and `tests/pilot_ci.py` resolves as a sibling import under pytest inside the pilot binary as well as under plain python.
