### PR TITLE
Leave the exhaustive pilot theme matrix to the nightly lane

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -224,8 +224,10 @@ jobs:
           install_name_tool -add_rpath $(qtpaths --install-prefix)/lib ${PYSIDE6_PATH}/QtCore.abi3.so
           JOB_MAKE_ARGS="${JOB_MAKE_ARGS} BUILD_METAL=ON" ; \
         fi
-        # Left at the default so one job runs the GUI tests with their windows
-        # off the screen; run_pilot_pytest below maps its windows.
+        # The live-window widget classes run once per OS, in run_pilot_pytest
+        # below; what stays here needs no window, so SOLVCON_TEST_SHOW_WINDOWS
+        # is left at the default. A schedule run leaves the guard empty.
+        export SOLVCON_SKIP_PILOT_WIDGET_TESTS=${{ github.event_name != 'schedule' && '1' || '' }}
         make pytest ${JOB_MAKE_ARGS}
         echo "::endgroup::"
 

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -249,6 +249,11 @@ jobs:
         # A runner has no desktop to take over, so let this job map its windows
         # and keep the tests that need a live surface out of the skips.
         export SOLVCON_TEST_SHOW_WINDOWS=ON
+        # A theme switch repolishes every widget, so the exhaustive theme and
+        # terminal color matrix costs more than the rest of the suite. A pull
+        # request runs the smoke slice, one dark and light round trip; the
+        # nightly schedule leaves the guard empty and runs the matrix.
+        export SOLVCON_PILOT_SMOKE=${{ github.event_name != 'schedule' && '1' || '' }}
         make run_pilot_pytest VERBOSE=1
         echo "::endgroup::"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,13 @@ without installation, and works around macOS SIP stripping `DYLD_LIBRARY_PATH`.
   does not take over the desktop (`tests/conftest.py`). Export
   `SOLVCON_TEST_SHOW_WINDOWS=ON` to watch the windows instead, which hands
   them the desktop and the keyboard for the length of the run.
+- The pull-request CI lane runs the pilot GUI tests once instead of twice, and
+  only a smoke slice of the theme and terminal matrix; the nightly schedule
+  runs everything (`tests/pilot_ci.py` explains the two guards). Local runs are
+  never guarded, so run the full suite yourself when you touch
+  `cpp/solvcon/pilot/theme/`, `solvcon/pilot/base/_theme.py`,
+  `tests/test_pilot_theme.py`, or `tests/test_pilot_terminal.py`; otherwise a
+  regression there waits for the nightly email.
 - `make gtest` -- build and run the full C++ test suite.
 - `./build/rel<pyvminor>/gtests/run_gtest --gtest_filter=Suite.Test` -- run a
   single gtest after `make gtest` has built the binary

--- a/tests/pilot_ci.py
+++ b/tests/pilot_ci.py
@@ -14,8 +14,17 @@ exercises, so it keeps the full GUI pass, and the python pass exports
 runs the headless pilot classes and the whole non-GUI suite. A developer
 running ``make pytest`` leaves the variable unset and sees no change.
 
-The guard is an environment variable rather than a pytest marker because both
-Qt hosts read it the same way, the test files stay pure unittest, and they
+The pilot binary's pass is in turn dominated by the theme and terminal color
+matrix, because a theme switch repolishes every widget in the process. On a
+pull request it therefore exports ``SOLVCON_PILOT_SMOKE`` too, which drops the
+exhaustive classes and keeps a smoke slice: one dark and light round trip
+through the whole widget tree, and the terminal editing behavior. The
+nightly schedule leaves both variables unset and runs the full cross product,
+so a theme regression the smoke slice misses is reported by nightly email the
+next morning instead of on the pull request.
+
+The guards are environment variables rather than pytest markers because both
+Qt hosts read them the same way, the test files stay pure unittest, and they
 remain usable under plain ``python -m unittest``.
 """
 
@@ -28,5 +37,7 @@ def _flag(name):
 
 
 SKIP_PILOT_WIDGETS = _flag('SOLVCON_SKIP_PILOT_WIDGET_TESTS')
+PILOT_SMOKE = _flag('SOLVCON_PILOT_SMOKE')
+SMOKE_SKIP_REASON = "the exhaustive theme matrix runs on the nightly lane"
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/pilot_ci.py
+++ b/tests/pilot_ci.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Let CI run each pilot GUI test once per operating system.
+
+Every pilot GUI test runs twice on a pull request: once under python plus
+PySide6 (``make pytest BUILD_QT=ON``) and once inside the pilot binary
+(``make run_pilot_pytest``), and the widget classes are where both passes
+spend their time. The pilot binary embeds the interpreter nothing else
+exercises, so it keeps the full GUI pass, and the python pass exports
+``SOLVCON_SKIP_PILOT_WIDGET_TESTS`` to drop the widget classes while it still
+runs the headless pilot classes and the whole non-GUI suite. A developer
+running ``make pytest`` leaves the variable unset and sees no change.
+
+The guard is an environment variable rather than a pytest marker because both
+Qt hosts read it the same way, the test files stay pure unittest, and they
+remain usable under plain ``python -m unittest``.
+"""
+
+
+import os
+
+
+def _flag(name):
+    return (os.getenv(name) or '').upper() in ('1', 'ON', 'YES', 'TRUE')
+
+
+SKIP_PILOT_WIDGETS = _flag('SOLVCON_SKIP_PILOT_WIDGET_TESTS')
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -13,6 +13,7 @@ from xml.etree import ElementTree
 import numpy as np
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -389,7 +390,7 @@ class R2DWidgetWorldTC(unittest.TestCase):
                 "circle interior should be hollow")
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "live-GUI interaction needs a real window surface")
 class R2DWidgetSelectToolTC(unittest.TestCase):
     """Drive the select tool through select, move, rotate, and deselect."""
@@ -1049,7 +1050,7 @@ class R2DWidgetExportOverlayTC(unittest.TestCase):
         self.assertGreater(labeled, plain)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "theme switching needs a real window surface")
 class R2DWidgetThemeTC(unittest.TestCase):
     """The painted frame follows the theme, not just the palette the widget
@@ -1098,7 +1099,7 @@ class R2DWidgetThemeTC(unittest.TestCase):
                                  self.widget.canvasPalette["background"])
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "live-GUI interaction needs a real window surface")
 class PainterToolboxTC(unittest.TestCase):
     """Run-through coverage of the Painter toolbox and the 'Create blank 2D

--- a/tests/test_pilot_agent.py
+++ b/tests/test_pilot_agent.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -55,7 +56,7 @@ class _TranslateBackend:
                  "dx": 1.0, "dy": 0.0}])
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class AgentPanelTC(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pilot_agent_control.py
+++ b/tests/test_pilot_agent_control.py
@@ -12,6 +12,7 @@ import tempfile
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot, agent
@@ -30,7 +31,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class _PilotTC(unittest.TestCase):
     """Shared setup: a shown main window with an empty MDI area, so every

--- a/tests/test_pilot_bar.py
+++ b/tests/test_pilot_bar.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -22,7 +23,7 @@ BUILTINS = ["File", "Edit", "View", "One", "Mesh", "Canvas", "Profiling",
             "Window"]
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class BarStructureTC(unittest.TestCase):
     def test_full_bar_is_assembled_from_the_model(self):

--- a/tests/test_pilot_camera_menu.py
+++ b/tests/test_pilot_camera_menu.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -19,7 +20,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class CameraMenuTC(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pilot_draw_tool.py
+++ b/tests/test_pilot_draw_tool.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -66,7 +67,7 @@ class PainterIconTC(unittest.TestCase):
                 self.assertLess(scaled[3], 2 * self._SIZE - 1)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class DrawToolTC(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pilot_menu_model.py
+++ b/tests/test_pilot_menu_model.py
@@ -7,6 +7,7 @@ import itertools
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -25,7 +26,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
 _TAG = itertools.count()
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class MenuModelTC(unittest.TestCase):
     def setUp(self):
@@ -95,7 +96,7 @@ class MenuModelTC(unittest.TestCase):
                          [self.tag + "B", self.tag + "A"])
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class MenuPlacementTC(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pilot_painter_design.py
+++ b/tests/test_pilot_painter_design.py
@@ -10,6 +10,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -240,7 +241,7 @@ class PainterDesignPageTC(unittest.TestCase):
         self.assertNotEqual(self.page._icon.pixmap().toImage(), icon)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class PainterDesignCanvasTC(unittest.TestCase):
     """The page against a real canvas, bound by the Painter dock."""

--- a/tests/test_pilot_painter_layers.py
+++ b/tests/test_pilot_painter_layers.py
@@ -10,6 +10,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -221,7 +222,7 @@ class PainterLayersPageTC(unittest.TestCase):
         self.assertNotEqual(self.page.shown_rows[0].icon.toImage(), icon)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class PainterLayersCanvasTC(unittest.TestCase):
     """The page against a real canvas, bound by the Painter dock."""

--- a/tests/test_pilot_shortcut.py
+++ b/tests/test_pilot_shortcut.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -220,7 +221,7 @@ class ShortcutResolutionTC(unittest.TestCase):
         self.assertIn(frozenset({"edit.undo", "window.console"}), pairs)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ShortcutTC(unittest.TestCase):
     """Live QAction bindings for the commands routed through the roof."""
@@ -280,7 +281,7 @@ class ShortcutTC(unittest.TestCase):
             self.assertEqual(action.menuRole(), QtGui.QAction.NoRole)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ApplyShortcutHelperTC(unittest.TestCase):
     """apply_shortcut installs a binding by objectName without hand wiring."""
@@ -310,7 +311,8 @@ class ApplyShortcutHelperTC(unittest.TestCase):
         self.assertEqual(act.menuRole(), QtGui.QAction.AboutRole)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT or QTest is None,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS
+                 or not solvcon.HAS_PILOT or QTest is None,
                  "live key delivery needs a real window surface and QtTest")
 class DrawToolShortcutTC(unittest.TestCase):
     """The draw-tool letters reach a focused canvas and nothing else."""

--- a/tests/test_pilot_solution_info.py
+++ b/tests/test_pilot_solution_info.py
@@ -9,6 +9,7 @@ import unittest
 import numpy as np
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 from solvcon.multidim.euler import oblique
 
 try:
@@ -70,7 +71,7 @@ class ComputeFieldTC(unittest.TestCase):
             density, svr.so0n.ndarray[svr.ngstcell:, 0])
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class SolutionInfoTC(unittest.TestCase):
     def setUp(self):
@@ -189,7 +190,7 @@ class SolutionInfoTC(unittest.TestCase):
         QApplication.processEvents()
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class SolutionInspectorTC(unittest.TestCase):
     """The wired controller refreshes the inspector when a run sets the

--- a/tests/test_pilot_terminal.py
+++ b/tests/test_pilot_terminal.py
@@ -14,6 +14,7 @@ events, so they need the Qt pilot but no on-screen rendering.
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -35,8 +36,9 @@ def _send_key(widget, key, text="", mod=None):
         QtWidgets.QApplication.sendEvent(widget, event)
 
 
-@unittest.skipUnless(solvcon.HAS_PILOT and pilot is not None,
-                     "Qt pilot is not built")
+@unittest.skipUnless(solvcon.HAS_PILOT and pilot is not None
+                     and not SKIP_PILOT_WIDGETS,
+                     "Qt pilot is not built, or widget tests are skipped")
 class TerminalWidgetTC(unittest.TestCase):
 
     @classmethod

--- a/tests/test_pilot_terminal.py
+++ b/tests/test_pilot_terminal.py
@@ -14,7 +14,7 @@ events, so they need the Qt pilot but no on-screen rendering.
 import unittest
 
 import solvcon
-from pilot_ci import SKIP_PILOT_WIDGETS
+from pilot_ci import PILOT_SMOKE, SKIP_PILOT_WIDGETS, SMOKE_SKIP_REASON
 
 try:
     from solvcon import pilot
@@ -213,6 +213,7 @@ class TerminalWidgetTC(unittest.TestCase):
         pos = self.edit.toPlainText().find("pass")
         self.assertNotIn((0, 0, 180), self._layout_colors(pos))
 
+    @unittest.skipIf(PILOT_SMOKE, SMOKE_SKIP_REASON)
     def test_stderr_output_is_red(self):
         self.term.command = "1 / 0"
         self.term.executeCommand()
@@ -222,6 +223,7 @@ class TerminalWidgetTC(unittest.TestCase):
         self.assertEqual((color.red(), color.green(), color.blue()),
                          (170, 0, 0))
 
+    @unittest.skipIf(PILOT_SMOKE, SMOKE_SKIP_REASON)
     def test_stdout_output_uses_the_theme_text_color(self):
         self.term.command = "print('marker_out')"
         self.term.executeCommand()
@@ -232,6 +234,7 @@ class TerminalWidgetTC(unittest.TestCase):
         self.assertEqual((color.red(), color.green(), color.blue()),
                          (expected.red(), expected.green(), expected.blue()))
 
+    @unittest.skipIf(PILOT_SMOKE, SMOKE_SKIP_REASON)
     def test_output_colors_follow_a_dark_switch(self):
         # Under the dark theme the captured stderr stays red-dominant but
         # takes a distinct, brighter value than the light table's, and stdout

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -6,7 +6,7 @@ import os
 import unittest
 
 import solvcon
-from pilot_ci import SKIP_PILOT_WIDGETS
+from pilot_ci import PILOT_SMOKE, SKIP_PILOT_WIDGETS, SMOKE_SKIP_REASON
 
 try:
     from solvcon import pilot
@@ -68,6 +68,7 @@ class ThemeManagerTC(unittest.TestCase):
         self.assertEqual(self.mgr.theme_mode, "system")
 
 
+@unittest.skipIf(PILOT_SMOKE, SMOKE_SKIP_REASON)
 @unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeMenuTC(unittest.TestCase):
@@ -129,6 +130,7 @@ class ThemeMenuTC(unittest.TestCase):
         self.assertEqual(checked.objectName(), "theme.mode_dark")
 
 
+@unittest.skipIf(PILOT_SMOKE, SMOKE_SKIP_REASON)
 @unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeLookTC(unittest.TestCase):
@@ -182,6 +184,7 @@ class ThemeLookTC(unittest.TestCase):
                          "theme.look_system")
 
 
+@unittest.skipIf(PILOT_SMOKE, SMOKE_SKIP_REASON)
 @unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemePolishTC(unittest.TestCase):
@@ -218,6 +221,7 @@ class ThemePolishTC(unittest.TestCase):
         self.assertEqual(settings.value("theme/look"), "system")
 
 
+@unittest.skipIf(PILOT_SMOKE, SMOKE_SKIP_REASON)
 @unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeCanvasTC(unittest.TestCase):
@@ -267,6 +271,7 @@ class ThemeCanvasTC(unittest.TestCase):
             self.app.palette().color(QPalette.Window).lightness())
 
 
+@unittest.skipIf(PILOT_SMOKE, SMOKE_SKIP_REASON)
 @unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeConsoleTC(unittest.TestCase):

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -25,7 +26,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeManagerTC(unittest.TestCase):
     def setUp(self):
@@ -67,7 +68,7 @@ class ThemeManagerTC(unittest.TestCase):
         self.assertEqual(self.mgr.theme_mode, "system")
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeMenuTC(unittest.TestCase):
     def setUp(self):
@@ -128,7 +129,7 @@ class ThemeMenuTC(unittest.TestCase):
         self.assertEqual(checked.objectName(), "theme.mode_dark")
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeLookTC(unittest.TestCase):
     def setUp(self):
@@ -181,7 +182,7 @@ class ThemeLookTC(unittest.TestCase):
                          "theme.look_system")
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemePolishTC(unittest.TestCase):
     def setUp(self):
@@ -217,7 +218,7 @@ class ThemePolishTC(unittest.TestCase):
         self.assertEqual(settings.value("theme/look"), "system")
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeCanvasTC(unittest.TestCase):
     """The 2D canvas fills every pixel itself instead of letting the style
@@ -266,7 +267,7 @@ class ThemeCanvasTC(unittest.TestCase):
             self.app.palette().color(QPalette.Window).lightness())
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ThemeConsoleTC(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pilot_toggle_action.py
+++ b/tests/test_pilot_toggle_action.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -21,7 +22,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class ToggleActionBridgeTC(unittest.TestCase):
 

--- a/tests/test_pilot_tree_panel.py
+++ b/tests/test_pilot_tree_panel.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -140,7 +141,7 @@ class MakeMeshInfoTC(unittest.TestCase):
         self.assertEqual(binfo, [[0, mh.nbound]])
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class MeshInfoTreeTC(unittest.TestCase):
     def setUp(self):
@@ -161,7 +162,7 @@ class MeshInfoTreeTC(unittest.TestCase):
                          Qt.Checked)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class EntityTreeWidgetTC(unittest.TestCase):
     def setUp(self):
@@ -197,7 +198,7 @@ class EntityTreeWidgetTC(unittest.TestCase):
         self.assertFalse(tree._timer.isActive())
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class TreePanelTC(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pilot_ui_state.py
+++ b/tests/test_pilot_ui_state.py
@@ -12,6 +12,7 @@ import tempfile
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -45,7 +46,7 @@ class FakePart(object):
         return self.value
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class GeometrySeamTC(unittest.TestCase):
     """Drive the geometry policy against a hidden, fully controlled window.
@@ -109,7 +110,7 @@ class GeometrySeamTC(unittest.TestCase):
         self.assertEqual(part.capture()["height"], 420)
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class UiStateTC(unittest.TestCase):
     """UiState coordinates any number of named parts, not windows alone."""

--- a/tests/test_pilot_window_menu.py
+++ b/tests/test_pilot_window_menu.py
@@ -14,6 +14,7 @@ import os
 import unittest
 
 import solvcon
+from pilot_ci import SKIP_PILOT_WIDGETS
 
 try:
     from solvcon import pilot
@@ -30,7 +31,7 @@ NO_LIVE_WINDOW = ((os.getenv('QT_QPA_PLATFORM') or '').startswith('offscreen')
                   or ('nt' == os.name and bool(os.getenv('GITHUB_ACTIONS'))))
 
 
-@unittest.skipIf(NO_LIVE_WINDOW or not solvcon.HAS_PILOT,
+@unittest.skipIf(NO_LIVE_WINDOW or SKIP_PILOT_WIDGETS or not solvcon.HAS_PILOT,
                  "pilot windows need a real window surface")
 class WindowMenuTC(unittest.TestCase):
     """Drive the WindowManager list through the live "Window" menu."""


### PR DESCRIPTION
Validation run on the fork. Stacked on #19. Related to #1222.

A theme switch repolishes every widget in the process, so the exhaustive theme and terminal color matrix costs more than the rest of the suite put together. This adds a second guard, `SOLVCON_PILOT_SMOKE`, that drops `ThemeMenuTC`, `ThemeLookTC`, `ThemePolishTC`, `ThemeCanvasTC`, `ThemeConsoleTC`, and the three terminal color tests on the pull-request lane, keeping a smoke slice: `ThemeManagerTC` for one dark and light round trip through the whole widget tree, plus the terminal editing behavior.

The schedule event leaves the guard empty, so the nightly `build` job runs the full cross product, exactly what a pull request runs today, and `send_email_on_fail.yml` already reports its failures. The accepted trade is that a theme regression the smoke slice misses is reported by nightly email the next morning instead of on the pull request. CLAUDE.md now tells contributors touching theme or terminal code to run the full suite locally.

The terminal saving here is small on its own, 3 of 21 tests or about 14 percent of that file, because `setUp` pins the theme for every test that runs. Moving that pin is separate work.

What this run is meant to prove: the smoke slice passes in the pilot binary and the two guards compose without skipping more than intended.
